### PR TITLE
Improved documentation on ISO images

### DIFF
--- a/user-guide/gui/datacenters/iso_images.rst
+++ b/user-guide/gui/datacenters/iso_images.rst
@@ -40,6 +40,8 @@ ISO Image Parameters
 * **Description**
 
 
+.. _managing_iso_image:
+
 Managing an ISO Image
 =====================
 

--- a/user-guide/gui/servers/details.rst
+++ b/user-guide/gui/servers/details.rst
@@ -114,7 +114,7 @@ Virtual Server Actions
 
     .. note:: It is possible to perform the migration only between node storages (zpools) with the same name. Migration between node storages with different names can be performed via the :ref:`API <api>`.
 * **Replication** - :ref:`Create or manage replicas of this virtual server <vm_replication>`. The virtual server must be in a *running* or *stopped* state (*Danube Cloud Enterprise Edition*).
-* **Boot CD** - Start the virtual server from an ISO image (KVM only). The virtual server must be in a *stopped* state.
+* **Boot CD** - Start the virtual server from an ISO image (KVM only). The virtual server must be in a *stopped* state. For instructions on how to add/manage ISO images see :ref:`Managing an ISO Image <managing_iso_image>`.
 
     .. image:: img/vm_boot_cd.png
 * **Factory reset** - Destroy and recreate the virtual server on compute node. The virtual server must be in a *stopped* state.


### PR DESCRIPTION
Added cross-reference from section about servers Boot CD option to section on managing ISO images, so that user immediately can find relevant section on how to add custom ISO image.